### PR TITLE
Feature: slice(offset, length) method

### DIFF
--- a/intel-hex.js
+++ b/intel-hex.js
@@ -731,7 +731,7 @@ class MemoryMap {
     clone() {
         const cloned = new MemoryMap();
 
-        for (var [addr, value] of this) {
+        for (let [addr, value] of this) {
             cloned.set(addr, new Uint8Array(value));
         }
 
@@ -817,6 +817,40 @@ class MemoryMap {
         return memMap;
     }
 
+
+    /**
+     * Returns a new instance of <tt>MemoryMap</tt>, containing only data between
+     * <tt>offset</tt> and <tt>offset</tt> + <tt>length</tt>.
+     *
+     * <br/>
+     * The returned <tt>MemoryMap</tt> might be empty.
+     * <br/>
+     * Internally, this uses <tt>subarray</tt>, so new memory is not allocated.
+     *
+     * @param {Number} offset The start offset
+     * @param {Number} length The lenght of memory map to slice out
+     * @return {MemoryMap}
+     */
+    slice(offset, length){
+        const sliced = new MemoryMap();
+
+        for (let [blockAddr, block] of this) {
+            const blockLength = block.length;
+
+            if ((blockAddr + length) >= offset && blockAddr < (offset + length)) {
+                const sliceStart = Math.max(offset, blockAddr);
+                const sliceEnd = Math.min(offset + length, blockAddr + blockLength);
+                const sliceLength = sliceEnd - sliceStart;
+                const relativeSliceStart = sliceStart - blockAddr;
+
+                if (sliceLength) {
+                    sliced.set(sliceStart, block.subarray(relativeSliceStart, relativeSliceStart + sliceLength));
+                }
+            }
+
+        }
+        return sliced;
+    }
 }
 
 

--- a/intel-hex.js
+++ b/intel-hex.js
@@ -482,7 +482,8 @@ class MemoryMap {
      * Returns a new instance of {@linkcode MemoryMap}, where:
      *
      * <ul>
-     *  <li>Each address is a multiple of <tt>pageSize</tt></li>
+     *  <li>Each key (the start address of each <tt>Uint8Array</tt>) is a multiple of
+     *    <tt>pageSize</tt></li>
      *  <li>The size of each <tt>Uint8Array</tt> is exactly <tt>pageSize</tt></li>
      *  <li>Bytes from the input map to bytes in the output</li>
      *  <li>Bytes not in the input are replaced by a padding value</li>
@@ -819,38 +820,45 @@ class MemoryMap {
 
 
     /**
-     * Returns a new instance of <tt>MemoryMap</tt>, containing only data between
-     * <tt>offset</tt> and <tt>offset</tt> + <tt>length</tt>.
+     * Returns a new instance of {@linkcode MemoryMap}, containing only data between
+     * the addresses <tt>address</tt> and <tt>address + length</tt>.
+     * Behaviour is similar to {@linkcode https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/slice|Array.prototype.slice},
+     * in that the return value is a portion of the current {@linkcode MemoryMap}.
      *
      * <br/>
-     * The returned <tt>MemoryMap</tt> might be empty.
+     * The returned {@linkcode MemoryMap} might be empty.
+     *
      * <br/>
      * Internally, this uses <tt>subarray</tt>, so new memory is not allocated.
      *
-     * @param {Number} offset The start offset
+     * @param {Number} address The start address of the slice
      * @param {Number} length The lenght of memory map to slice out
      * @return {MemoryMap}
      */
-    slice(offset, length){
+    slice(address, length = Infinity){
+        if (length < 0) {
+            throw new Error('Length of the slice cannot be negative');
+        }
+
         const sliced = new MemoryMap();
 
         for (let [blockAddr, block] of this) {
             const blockLength = block.length;
 
-            if ((blockAddr + length) >= offset && blockAddr < (offset + length)) {
-                const sliceStart = Math.max(offset, blockAddr);
-                const sliceEnd = Math.min(offset + length, blockAddr + blockLength);
+            if ((blockAddr + length) >= address && blockAddr < (address + length)) {
+                const sliceStart = Math.max(address, blockAddr);
+                const sliceEnd = Math.min(address + length, blockAddr + blockLength);
                 const sliceLength = sliceEnd - sliceStart;
                 const relativeSliceStart = sliceStart - blockAddr;
 
-                if (sliceLength) {
+                if (sliceLength > 0) {
                     sliced.set(sliceStart, block.subarray(relativeSliceStart, relativeSliceStart + sliceLength));
                 }
             }
-
         }
         return sliced;
     }
+
 }
 
 

--- a/spec/intel-hex-parse-spec.js
+++ b/spec/intel-hex-parse-spec.js
@@ -1111,4 +1111,87 @@ describe("MemoryMap fromHex/asHex", function() {
             ]));
         });
     });
+
+
+    describe("slice", function() {
+        it('Empty identity', () => {
+            let memMap = new MemoryMap([]);
+
+            expect(memMap.slice(0,16)).toEqual(memMap);
+        });
+
+        it('contiguous 16-byte identity', () => {
+//             let bytes1 = (new Uint8Array(16)).map((i,j)=>j);
+//             let bytes2 = (new Uint8Array(16)).map((i,j)=>j+16);
+//             let bytes3 = (new Uint8Array(16)).map((i,j)=>j+32);
+//             let bytes4 = (new Uint8Array(16)).map((i,j)=>j+48);
+//             let memMap = new MemoryMap([
+//                 [0x050010, bytes3],
+//                 [0x000000, bytes1],
+//                 [0x050C30, bytes4],
+//                 [0x000800, bytes2]
+//             ]);
+
+            let bytes1 = (new Uint8Array(16)).map((i,j)=>j);
+            let memMap = new MemoryMap([
+                [0x000000, bytes1],
+            ]);
+
+            expect(memMap.slice(0, 16)).toEqual(memMap);
+            expect(memMap.slice(0, 32)).toEqual(memMap);
+
+            let memMap2 = new MemoryMap([
+                [0x000010, bytes1],
+            ]);
+
+            expect(memMap2.slice(16, 16)).toEqual(memMap2);
+            expect(memMap2.slice(0, 48)).toEqual(memMap2);
+        });
+
+        it('non-contiguous 16-byte identity', () => {
+            let bytes1 = (new Uint8Array(4)).map((i,j)=>j);
+            let bytes2 = (new Uint8Array(8)).map((i,j)=>j+8);
+            let memMap = new MemoryMap([
+                [0x000010, bytes1],
+                [0x000018, bytes2],
+            ]);
+
+            expect(memMap.slice(16, 16)).toEqual(memMap);
+            expect(memMap.slice(16, 32)).toEqual(memMap);
+            expect(memMap.slice(0, 48)).toEqual(memMap);
+        });
+
+        it('Slices a larger stream of bytes', () => {
+            let bytes1 = (new Uint8Array(64)).map((i,j)=>j);
+            let bytes2 = (new Uint8Array(16)).map((i,j)=>j+8);
+            let memMap = new MemoryMap([
+                [0x000000, bytes1],
+            ]);
+
+            expect(memMap.slice(8, 16)).toEqual(new MemoryMap([[0x08, bytes2]]));
+        });
+
+
+        it('Slices byte blocks at the beginning and end of the slice', () => {
+            let bytes1 = (new Uint8Array(16)).map((i,j)=>j);
+            let bytes2 = (new Uint8Array(16)).map((i,j)=>j+16);
+            let bytes3 = (new Uint8Array(16)).map((i,j)=>j+32);
+            let memMap = new MemoryMap([
+                [0x000100, bytes1],
+                [0x000200, bytes2],
+                [0x000300, bytes3],
+            ]);
+
+            let memMap2 = new MemoryMap([
+                [0x000108, bytes1.subarray(8, 16)],
+                [0x000200, bytes2],
+                [0x000300, bytes3.subarray(0, 8)],
+            ]);
+
+            expect(memMap.slice(0x108, 0x200)).toEqual(memMap2);
+        });
+
+    });
+
+
 });

--- a/spec/intel-hex-parse-spec.js
+++ b/spec/intel-hex-parse-spec.js
@@ -1114,6 +1114,17 @@ describe("MemoryMap fromHex/asHex", function() {
 
 
     describe("slice", function() {
+        it('Length sanity checks', () => {
+            let memMap = new MemoryMap([]);
+            expect(()=>{
+                memMap.slice(0, -10);
+            }).toThrow(new Error('Length of the slice cannot be negative'));
+
+            expect(()=>{
+                memMap.slice(10, -1);
+            }).toThrow(new Error('Length of the slice cannot be negative'));
+        });
+
         it('Empty identity', () => {
             let memMap = new MemoryMap([]);
 
@@ -1121,17 +1132,6 @@ describe("MemoryMap fromHex/asHex", function() {
         });
 
         it('contiguous 16-byte identity', () => {
-//             let bytes1 = (new Uint8Array(16)).map((i,j)=>j);
-//             let bytes2 = (new Uint8Array(16)).map((i,j)=>j+16);
-//             let bytes3 = (new Uint8Array(16)).map((i,j)=>j+32);
-//             let bytes4 = (new Uint8Array(16)).map((i,j)=>j+48);
-//             let memMap = new MemoryMap([
-//                 [0x050010, bytes3],
-//                 [0x000000, bytes1],
-//                 [0x050C30, bytes4],
-//                 [0x000800, bytes2]
-//             ]);
-
             let bytes1 = (new Uint8Array(16)).map((i,j)=>j);
             let memMap = new MemoryMap([
                 [0x000000, bytes1],
@@ -1147,6 +1147,17 @@ describe("MemoryMap fromHex/asHex", function() {
             expect(memMap2.slice(16, 16)).toEqual(memMap2);
             expect(memMap2.slice(0, 48)).toEqual(memMap2);
         });
+
+
+        it('zero-length slice is empty', () => {
+            let bytes1 = (new Uint8Array(16)).map((i,j)=>j);
+            let memMap = new MemoryMap([
+                [0x000000, bytes1],
+            ]);
+
+            expect(memMap.slice(8, 0)).toEqual(new MemoryMap());
+        });
+
 
         it('non-contiguous 16-byte identity', () => {
             let bytes1 = (new Uint8Array(4)).map((i,j)=>j);


### PR DESCRIPTION
The main use case for this is ""extracting"" or slicing out the UICR section of .hex files intended for nRF52 chips. Comparing the page is easier than reading all individual values (with `getUint32`) and looping.