### PR TITLE
Fix slicePad return type

### DIFF
--- a/intel-hex.js
+++ b/intel-hex.js
@@ -870,7 +870,7 @@ class MemoryMap {
      * @param {Number} address The start address of the slice
      * @param {Number} length The length of memory map to slice out
      * @param {Number} [padByte=0xFF] The value of the byte assumed to be used as padding
-     * @return {MemoryMap}
+     * @return {Uint8Array}
      */
     slicePad(address, length, padByte=0xFF){
         if (length < 0) {


### PR DESCRIPTION
The api documentation was indicating that `slicePad` was returning a `MemoryMap` but it is returning a `Uint8Array`.

P.S.: Thanks for that library !